### PR TITLE
Use domain scope by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ This includes all sub domains like abc.collection.litme.com.ua, handles http:// 
     saveState: always
     seeds:
         - url: http://collection.litme.com.ua/
-          include: 
-            - .*collection\.litme\.com.ua.*
-          scopeType: "host"
+          scopeType: "domain"
     
 ## Excluding trouble
 


### PR DESCRIPTION
If you are using the latest browsertrix [0.5.0-beta.4](https://github.com/webrecorder/browsertrix-crawler/releases/tag/0.5.0-beta.4), the new `domain` scope automatically includes subdomains, simplifying the configuration.