### PR TITLE
Improve default crawl by introducing block rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # browsertrix-yaml-examples
 YAML files for including and excluding things
 
+See the [browsertrix project](https://github.com/webrecorder/browsertrix-crawler) for more general documentation.
 
 ## Default and handy starter file
 This includes all sub domains like abc.collection.litme.com.ua, handles http:// to https:// conversions & subdomains.
@@ -8,10 +9,20 @@ This includes all sub domains like abc.collection.litme.com.ua, handles http:// 
     collection: "collection-litme-com-ua"
     workers: 16
     saveState: always
+
+    # A few examples that exclude parts of a page from being fetched and recorded. Feel free to add more
+    blockRules:
+      - url: google-analytics.com
+      - url: googletagmanager.com
+      - url: yandex.ru
+      - url: mycounter.ua
+      - url: facebook.(com|net)
+      #- url: youtube.com/embed/ # Uncomment this line to skip the recording of embedded YouTube videos
+
     seeds:
         - url: http://collection.litme.com.ua/
           scopeType: "domain"
-    
+
 ## Excluding trouble
 
 If you notice that a crawl is collecting duplicate links due to parameters, like 


### PR DESCRIPTION
Pending a more robust solution (as is being [discussed on Slack](https://sucho-archiving.slack.com/archives/C0351LF7G4W/p1647016523444749)), give some exposure to the idea of block rules. Block rules give us a fine-grained control of which page resources are fetched. For example, they could be used to prevent web analytics data or malware from being fetched and bundled up as part of the collection.

Some page resources, such as YouTube embeds or analytics trackers, may not need to be recorded because they are not cultural heritage resources or are not currently threatened by the war. Explicitly blocking the recording of these resources speeds up the crawl significantly because it frees up workers to start on the next page, instead of waiting around until the page times out to move on (some of these trackers may start blocking on their end if they think that you are a bot). In the case of YouTube embeds, it also reduces the size of the resulting collection archives significantly. The caveat is that embedded YouTube videos will not (re)play, but it is fairly trivial to rewrite the links to point to the current representation on YouTube if need be. The HTML markup pointing to these resources is still preserved as part of the web page being recorded.

I am suggesting that these improvements are significant enough to warrant using this approach in the default template for the SUCHO project.